### PR TITLE
Create a symbolic link for /etc/mtab

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -71,6 +71,9 @@ RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/local_libs.conf
 # do not ask systemd for user IDs or groups (slows down dbus-daemon start)
 RUN sed -i s/systemd// /etc/nsswitch.conf
 
+# ganesha reads /etc/mtab for mounted volumes
+RUN ln -sf /proc/self/mounts /etc/mtab
+
 COPY --from=build /usr/local /usr/local/
 COPY --from=build /ganesha-extra /
 COPY bin/longhorn-share-manager /longhorn-share-manager


### PR DESCRIPTION
When ganesha starts, it looks for volume mount data in /etc/mtab. However, this file does not pre-exist in the Ubuntu image and results in the created pod hanging at ganesha server error.

```
mount.nfs: mounting 10.43.228.161:/pvc-3d9bd71e-e7ab-4420-bffa-b158e7de9186 failed, reason given by server: No such file or directory
```

Since mostly /etc/mtab is a copy of /proc/mounts hence it should be safe to have as a symbolic link.

https://github.com/longhorn/longhorn/issues/2111#issuecomment-786402108