### PR TITLE
volume(RWX)挂载权限修改

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -64,7 +64,8 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /var/run/dbus \
-    && mkdir -p /export
+    && mkdir -p /export \
+    && chmod 666 /export
 
 # add libs from /usr/local/lib64
 RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/local_libs.conf


### PR DESCRIPTION
使用longhorn，在K8S平台上挂载RWX，文件夹默认权限为644，在某些情况下可能会导致挂载的文件夹有权限问题，进而导致pod无法启动（如：kube-prometheus中的grafana采用longhorn的storageclass建立一个pvc进行持久化工作，grafana无法启动），这里修改文件夹挂载后的权限为666，以适应更多的情况。