### PR TITLE
Fix nfs share-mount ownership reset to nobody

### DIFF
--- a/pkg/server/nfs/nfs_server.go
+++ b/pkg/server/nfs/nfs_server.go
@@ -41,6 +41,7 @@ NFSV4
     Grace_Period = 0;
     Minor_Versions = 1, 2;
     RecoveryBackend = fs_ng;
+    Only_Numeric_Owners = true;
 }
 
 Export_defaults


### PR DESCRIPTION
Enable only numeric owners so nfsidmap domain does not have to be in sync between server and client.

https://github.com/longhorn/longhorn/issues/2357#issuecomment-812718469