### PR TITLE
Set volume mount dir permissions to 0777

### DIFF
--- a/pkg/server/share_manager.go
+++ b/pkg/server/share_manager.go
@@ -55,6 +55,11 @@ func (m *ShareManager) Run() error {
 				break
 			}
 
+			if err := setPermissions(m.volume, 0777); err != nil {
+				log.WithError(err).Error("failed to set permissions for volume")
+				break
+			}
+
 			log.Info("starting nfs server, volume is ready for export")
 			go m.runHealthCheck()
 

--- a/pkg/server/volume.go
+++ b/pkg/server/volume.go
@@ -47,6 +47,14 @@ func mountVolume(volume string) error {
 	return mounter.FormatAndMount(devicePath, mountPath, "ext4", nil)
 }
 
+func setPermissions(volume string, mode os.FileMode) error {
+	if !checkMountValid(volume) {
+		return fmt.Errorf("cannot set permissions %v for volume %v invalid mount point", mode, volume)
+	}
+	mountPath := filepath.Join(exportPath, volume)
+	return os.Chmod(mountPath, mode)
+}
+
 func unmountVolume(volume string) error {
 	mountPath := filepath.Join(exportPath, volume)
 	mounter := mount.New("")
@@ -57,7 +65,7 @@ func unmountVolume(volume string) error {
 // If pathname already exists as a directory, no error is returned.
 // If pathname already exists as a file, an error is returned.
 func makeDir(pathname string) error {
-	err := os.MkdirAll(pathname, os.FileMode(0755))
+	err := os.MkdirAll(pathname, os.FileMode(0777))
 	if err != nil {
 		if !os.IsExist(err) {
 			return err


### PR DESCRIPTION
Since we don't have any ACL on the nfs server we can just make the base
directory world writeable by all, this should allow for usage by non
root pods. Since permissions on RWX volumes are not set by kubernetes,
they normally would be root only, any file/folder that gets created by
the pod should have the correct owner/permissions.

longhorn/longhorn#2418

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
