### PR TITLE
Use stdoutBuf.String() instead of string(stdoutBuf.Bytes())

### DIFF
--- a/pkg/crypto/luks.go
+++ b/pkg/crypto/luks.go
@@ -59,7 +59,7 @@ func cryptSetupWithPassphrase(passphrase string, args ...string) (stdout string,
 		cmd.Stdin = strings.NewReader(passphrase)
 	}
 
-	output := string(stdoutBuf.Bytes())
+	output := stdoutBuf.String()
 	if err := cmd.Run(); err != nil {
 		return output, fmt.Errorf("failed to run cryptsetup args: %v output: %v error: %v", args, output, err)
 	}


### PR DESCRIPTION
Signed-off-by: Soumik Majumder <soumik712@gmail.com>
 
Caught by [Sonatype Lift](https://lift.sonatype.com/result/longhorn/longhorn-share-manager/01FHW2M83EXD1QVP8H7YRMH23E?t=CustomTool%20%22golangci-lint%22%7Cgosimple).