### PR TITLE
[For #4420] Add SetConfigParams() to determine nfs-ganesha log level

### DIFF
--- a/pkg/server/nfs/nfs_server.go
+++ b/pkg/server/nfs/nfs_server.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	defaultLogFile = "/tmp/ganesha.log"
 	defaultPidFile = "/var/run/ganesha.pid"
 )
 
@@ -29,8 +28,18 @@ NFS_Core_Param
     Protocols = 4;
 }
 
-# uncomment to enable debug logging
-# LOG { COMPONENTS { NFS_V4 = FULL_DEBUG; } }
+LOG {
+	Default_Log_Level = INFO;
+
+# 	uncomment to enable debug logging
+#	COMPONENTS { NFS_V4 = FULL_DEBUG; }
+
+	Facility {
+		name = FILE;
+		destination = "/proc/1/fd/1";
+		enable = active;
+	}
+}
 
 NFSV4
 {
@@ -105,7 +114,7 @@ func NewServer(logger logrus.FieldLogger, configPath, exportPath, volume string)
 func (s *Server) Run(ctx context.Context) error {
 	// Start ganesha.nfsd
 	s.logger.Info("Running NFS server!")
-	cmd := exec.CommandContext(ctx, "ganesha.nfsd", "-F", "-L", defaultLogFile, "-p", defaultPidFile, "-f", s.configPath)
+	cmd := exec.CommandContext(ctx, "ganesha.nfsd", "-F", "-p", defaultPidFile, "-f", s.configPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("ganesha.nfsd failed with error: %v, output: %s", err, out)
 	}


### PR DESCRIPTION
I add `SetConfigParams()` which is according to different case to replace parameter of `defaultConfig`. 

For #4420, I replace `Default_Log_Level` value based on whether debug is turn on or not.

And it will only applied if configuration file is not exits.