### PR TITLE
fix: replace PPID to using PID to get initial process

### DIFF
--- a/pkg/server/nfs/nfs_server.go
+++ b/pkg/server/nfs/nfs_server.go
@@ -151,7 +151,7 @@ func getUpdatedGaneshConfig(config []byte) []byte {
 		logPath string
 	)
 
-	if os.Getppid() == 1 {
+	if os.Getpid() == 1 {
 		logPath = "/proc/1/fd/1"
 	} else {
 		logPath = "/tmp/ganesha.log"
@@ -164,5 +164,6 @@ func getUpdatedGaneshConfig(config []byte) []byte {
 	}
 
 	template.Must(template.New("Ganesha_Config").Parse(string(config))).Execute(&tmplBuf, tmplVals)
+
 	return tmplBuf.Bytes()
 }


### PR DESCRIPTION
Source issue: [#2380](https://github.com/longhorn/longhorn/issues/2380)

Original is using PPID to determine initial process, since parent process of initial process will be 0. So it will make the log path always be `/tmp/ganesha.log`. 

Therefor, fix to modify as getting the PID to determine initial process.