### PR TITLE
Create volume export config when volume is ready

### DIFF
--- a/pkg/server/nfs/nfs_server.go
+++ b/pkg/server/nfs/nfs_server.go
@@ -100,16 +100,16 @@ func NewServer(logger logrus.FieldLogger, configPath, exportPath, volume string)
 		return nil, errors.Wrap(err, "error creating nfs exporter")
 	}
 
-	if _, err := exporter.CreateExport(volume); err != nil {
-		return nil, err
-	}
-
 	return &Server{
 		logger:     logger,
 		configPath: configPath,
 		exportPath: exportPath,
 		exporter:   exporter,
 	}, nil
+}
+
+func (s *Server) CreateExport(volume string) (uint16, error) {
+	return s.exporter.CreateExport(volume)
 }
 
 func (s *Server) Run(ctx context.Context) error {

--- a/pkg/server/share_manager.go
+++ b/pkg/server/share_manager.go
@@ -108,6 +108,11 @@ func (m *ShareManager) Run() error {
 			m.logger.Info("Starting nfs server, volume is ready for export")
 			go m.runHealthCheck()
 
+			if _, err := m.nfsServer.CreateExport(vol.Name); err != nil {
+				m.logger.WithError(err).Error("Failed to create nfs export")
+				return err
+			}
+
 			// This blocks until server exist
 			if err := m.nfsServer.Run(m.context); err != nil {
 				m.logger.WithError(err).Error("NFS server exited with error")


### PR DESCRIPTION
Originally, the volume export config is created when a share manager pod starts running. However, the volume detachment might clean up the config when share manager daemon is waiting for volume after introducing longhorn/longhorn#6829.

To fix the issue, create volume export config when volume is ready instead.

Longhorn/longhorn#6924