### PR TITLE
Explicitly install libjson-c5 in bci-base:15.6

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -45,7 +45,7 @@ RUN zypper addrepo --refresh https://download.opensuse.org/repositories/system:/
     zypper --gpg-auto-import-keys ref
 
 # RUN microdnf install -y nano tar lsof e2fsprogs fuse-libs libss libblkid userspace-rcu dbus-x11 rpcbind hostname nfs-utils xfsprogs jemalloc libnfsidmap && microdnf clean all
-RUN zypper -n install rpcbind hostname libblkid1 liburcu6 dbus-1-x11 dbus-1 nfsidmap-devel nfs-kernel-server nfs-client nfs4-acl-tools xfsprogs e2fsprogs awk && \
+RUN zypper -n install rpcbind hostname libblkid1 liburcu6 libjson-c5 dbus-1-x11 dbus-1 nfsidmap-devel nfs-kernel-server nfs-client nfs4-acl-tools xfsprogs e2fsprogs awk && \
     rm -rf /var/cache/zypp/*
 
 RUN mkdir -p /var/run/dbus && mkdir -p /export


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8166

#### What this PR does / why we need it:

If we keep using the (currently) beta container `bci-base:15.6` (per https://github.com/longhorn/longhorn-share-manager/pull/154), we need to explicitly install `libjson-c5` while building share-manager.

If we roll https://github.com/longhorn/longhorn-share-manager/pull/154 back for now, we should NOT merge this PR, as `bci-base:15.5` can only install `libjson-c3`.

#### Additional documentation or context

https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6629/testReport/tests/test_rwx/