### PR TITLE
Explicitly install libjson-c since nfs-ganesha requires it

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -45,7 +45,7 @@ RUN zypper addrepo --refresh https://download.opensuse.org/repositories/system:/
     zypper --gpg-auto-import-keys ref
 
 # RUN microdnf install -y nano tar lsof e2fsprogs fuse-libs libss libblkid userspace-rcu dbus-x11 rpcbind hostname nfs-utils xfsprogs jemalloc libnfsidmap && microdnf clean all
-RUN zypper -n install rpcbind hostname libblkid1 liburcu6 dbus-1-x11 dbus-1 nfsidmap-devel nfs-kernel-server nfs-client nfs4-acl-tools xfsprogs e2fsprogs awk && \
+RUN zypper -n install rpcbind hostname libblkid1 liburcu6 libjson-c* dbus-1-x11 dbus-1 nfsidmap-devel nfs-kernel-server nfs-client nfs4-acl-tools xfsprogs e2fsprogs awk && \
     rm -rf /var/cache/zypp/*
 
 RUN mkdir -p /var/run/dbus && mkdir -p /export


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

We no longer need this to close out longhorn/longhorn#8166. However, @james-munson and I think we should still explicitly install libjson-c in during the share-manager image build since we discovered it was an implicit requirement. This has no effect while we still use bci-base:15.5, but it will probably keep us from running into issues with bci-base:15.6 when we eventually upgrade.