### PR TITLE
chore: bump nfs-ganesha to v6.3

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -17,9 +17,9 @@ RUN zypper -n install autoconf bison curl cmake doxygen make git gcc14 gcc14-c++
     tar gzip dbus-1-devel lsb-release graphviz-devel libnsl-devel libcurl-devel libjson-c-devel libacl-devel && \
     rm -rf /var/cache/zypp/*
 
-RUN curl -L https://github.com/rancher/nfs-ganesha/archive/refs/tags/v6_20241120.tar.gz | tar zx \
+RUN curl -L https://github.com/rancher/nfs-ganesha/archive/refs/tags/v6_20241216.tar.gz | tar zx \
 	  && curl -L https://github.com/nfs-ganesha/ntirpc/archive/refs/tags/v6.0.1.tar.gz | tar zx \
-	  && mv nfs-ganesha-6_20241120 nfs-ganesha \
+	  && mv nfs-ganesha-6_20241216 nfs-ganesha \
 	  && rm -r nfs-ganesha/src/libntirpc \
 	  && mv ntirpc-6.0.1 nfs-ganesha/src/libntirpc
 WORKDIR /nfs-ganesha


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9979

#### What this PR does / why we need it:

#### Special notes for your reviewer:

Relies on new branch longhorn-ganesha-v6.3 in https://github.com/rancher/nfs-ganesha, with tag v6_20241216

Built but not yet tested.

#### Additional documentation or context
