### PR TITLE
chore(build): switch to ubuntu 22.04 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
 
   build_push_image:
     name: Build and push image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     if: ${{ startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/tags/') }}
     steps:


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10372

#### What this PR does / why we need it:

CI failed to build longhorn-share-manager since the action runner image was upgraded to 24.04 20250120.5.0.

#### Special notes for your reviewer:

#### Additional documentation or context
