### PR TITLE
Read and pass volume formatting options to the underlying mounter lib…

### DIFF
--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -87,6 +87,11 @@ func ServerCmd() cli.Command {
 				Usage:    "allows for specifying additional mount options",
 				Required: false,
 			},
+			cli.StringSliceFlag{
+				Name:     "format",
+				Usage:    "allows for specifying additional filesystem formatting options",
+				Required: false,
+			},
 		},
 		Action: func(c *cli.Context) {
 			vol := volume.Volume{
@@ -99,6 +104,7 @@ func ServerCmd() cli.Command {
 				CryptoPBKDF:     c.String("crytpopbkdf"),
 				FsType:          c.String("fs"),
 				MountOptions:    c.StringSlice("mount"),
+				FormatOptions:   c.StringSlice("format"),
 			}
 
 			if c.Bool("encrypted") && len(vol.Passphrase) == 0 {

--- a/pkg/server/share_manager.go
+++ b/pkg/server/share_manager.go
@@ -234,6 +234,7 @@ func (m *ShareManager) tearDownDevice(vol volume.Volume) error {
 func (m *ShareManager) MountVolume(vol volume.Volume, devicePath, mountPath string) error {
 	fsType := vol.FsType
 	mountOptions := vol.MountOptions
+	formatOptions := vol.FormatOptions
 
 	// https://github.com/longhorn/longhorn/issues/2991
 	// pre v1.2 we ignored the fsType and always formatted as ext4
@@ -251,7 +252,7 @@ func (m *ShareManager) MountVolume(vol volume.Volume, devicePath, mountPath stri
 		fsType = diskFormat
 	}
 
-	return volume.MountVolume(devicePath, mountPath, fsType, mountOptions)
+	return volume.MountVolume(devicePath, mountPath, fsType, mountOptions, formatOptions)
 }
 
 func (m *ShareManager) resizeVolume(devicePath, mountPath string) error {

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -19,6 +19,7 @@ type Volume struct {
 	CryptoPBKDF     string
 	FsType          string
 	MountOptions    []string
+	FormatOptions   []string
 }
 
 func (v Volume) IsEncrypted() bool {
@@ -40,7 +41,7 @@ func CheckMountValid(mountPath string) bool {
 	return err == nil && isMountPoint
 }
 
-func MountVolume(devicePath, mountPath, fsType string, mountOptions []string) error {
+func MountVolume(devicePath, mountPath, fsType string, mountOptions []string, formatOptions []string) error {
 	if !CheckDeviceValid(devicePath) {
 		return fmt.Errorf("cannot mount device %v to %v invalid device", devicePath, mountPath)
 	}
@@ -61,7 +62,8 @@ func MountVolume(devicePath, mountPath, fsType string, mountOptions []string) er
 		}
 	}
 
-	return mounter.FormatAndMount(devicePath, mountPath, fsType, mountOptions)
+	return mounter.FormatAndMountSensitiveWithFormatOptions(devicePath, mountPath, fsType,
+		mountOptions, nil, formatOptions)
 }
 
 func ResizeVolume(devicePath, mountPath string) (bool, error) {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #11107

#### What this PR does / why we need it:
We need to accept the new format options parameter which we get passed from the Longhorn Manager which are used to format volumes without an existing filesystem.

#### Special notes for your reviewer:
Depends on a change in the Longhorn Manager Repo which is tracked under the same issue

#### Additional documentation or context
