### PR TITLE
fix(crypto): encrypted volume live expansion

### DIFF
--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -151,11 +151,12 @@ func (s *ShareManagerServer) FilesystemResize(ctx context.Context, req *emptypb.
 
 	// Note that cryptsetup resize is only necessary for volumes resized while online.  For offline, it will happen automatically during 'open'.
 	if vol.IsEncrypted() {
-		diskFormat, err := volume.GetDiskFormat(devicePath)
+		rawDevicePath := types.GetRawVolumeDevicePath(vol.Name)
+		diskFormat, err := volume.GetDiskFormat(rawDevicePath)
 		if err != nil {
 			return &emptypb.Empty{}, grpcstatus.Errorf(grpccodes.Internal, "failed to determine disk format of volume %v: %v", vol.Name, err)
 		}
-		log.Infof("Device %v contains filesystem of format %v", devicePath, diskFormat)
+		log.WithField("mappedDevice", devicePath).Infof("Encrypted volume device %v contains filesystem of format %v", rawDevicePath, diskFormat)
 
 		if diskFormat != "crypto_LUKS" {
 			return &emptypb.Empty{}, grpcstatus.Errorf(grpccodes.InvalidArgument, "unsupported disk encryption format %v", diskFormat)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -37,6 +37,10 @@ func GetVolumeDevicePath(volumeName, dataEngine string, EncryptedDevice bool) st
 		}
 		return path.Join(MapperDevPath, volumeName)
 	}
+	return GetRawVolumeDevicePath(volumeName)
+}
+
+func GetRawVolumeDevicePath(volumeName string) string {
 	return filepath.Join(DevPath, "longhorn", volumeName)
 }
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11120

#### What this PR does / why we need it:

Reason: https://github.com/longhorn/longhorn/issues/11120#issuecomment-3012604761

1. Correct the LUKS device path.
2. Correct the device encryption status check logic. It should accepts both the following status:
    * `/path/to/device is active.`
    * `/path/to/device is active and is in use.`

#### Special notes for your reviewer:

#### Additional documentation or context
